### PR TITLE
gui es opcional en la instalacion

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,32 @@
+import subprocess
+import sys
 from setuptools import setup, find_packages
+
+install_requires = (["windows-curses; platform_system == 'Windows'"],)
+extras_require = {"gui": ["pygame"]}
+
+try:
+    import pygame  # noqa: F401
+except ImportError:
+    print("Pygame no está instalado. Intentando instalar...")
+    try:
+        subprocess.check_call([sys.executable, "-m", "pip", "install", "pygame"])
+        print("Pygame instalado exitosamente.")
+        install_requires.append("pygame")
+    except subprocess.CalledProcessError as e:
+        print(f"Error al instalar Pygame: {e}")
+        print("La instalación continuará sin soporte para Pygame.")
 
 setup(
     name="carreras",
     version="0.1",
     package_dir={"": "src"},
     packages=find_packages(where="src"),
-    install_requires=[
-        "pygame",
-        "windows-curses; platform_system == 'Windows'"
-    ],
+    install_requires=install_requires,
+    extras_require=extras_require,
     entry_points={
         "console_scripts": [
             "carreras=carreras.main:main",
         ],
     },
 )
-

--- a/src/carreras/main.py
+++ b/src/carreras/main.py
@@ -3,7 +3,16 @@
 import argparse
 
 from carreras.board import Board
-from carreras.graphicboard import GraphicBoard
+
+# Intenta importar pygame, si falla, usa curses
+try:
+    import pygame  # noqa: F401
+    from carreras.graphicboard import GraphicBoard
+
+    HAS_PYGAME = True
+except ImportError:
+    HAS_PYGAME = False
+
 from carreras.game import Game
 
 
@@ -57,7 +66,11 @@ def main():
     args = parser.parse_args()
 
     if args.gui:
-        board = GraphicBoard()
+        if HAS_PYGAME:
+            board = GraphicBoard()
+        else:
+            print("Pygame no está instalado. Usando interfaz de texto (curses) en su lugar.")
+            board = Board()
     else:
         board = Board()
 


### PR DESCRIPTION
## Summary by Sourcery

Make GUI support optional by introducing optional dependencies and dynamic installation of pygame during setup, and provide a fallback to the text interface when pygame is unavailable.

Enhancements:
- Move pygame and windows-curses requirements into a dynamic install_requires list and add an extras_require entry for GUI.
- Attempt to auto-install pygame via pip in setup.py if it's not already installed, while gracefully continuing without GUI support on failure.
- Modify main.py to check for pygame availability (HAS_PYGAME) and fall back to the text-based Board when GUI libraries are missing.